### PR TITLE
Add JSON file for RTX-KG2.6.7.1

### DIFF
--- a/files/kg2c_lite_2.6.7.1.json.gz
+++ b/files/kg2c_lite_2.6.7.1.json.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df39a27ace370d3aede59e39e009797c68408d94a5296491e9aa5126a249ebdd
+size 709462676


### PR DESCRIPTION
Added the KG JSON file (required by PloverDB) for the latest 'production' version of RTX-KG2 - 2.6.7.1.